### PR TITLE
Added ajax calls on approve/decline action

### DIFF
--- a/public/assets/js/utils.js
+++ b/public/assets/js/utils.js
@@ -33,6 +33,11 @@ function applyGridFilter(filter, item) {
 }
 
 $(document).ready(function () {
+    jsGrid.loadStrategies.DirectLoadingStrategy.prototype.finishDelete = function (deletedItem, deletedItemIndex) {
+        var grid = this._grid;
+        grid.option("data").splice(deletedItemIndex, 1);
+        grid.refresh();
+    };
     jsGrid.Grid.prototype._sortData = function () { //compensate sorting bug for nested data
         var self = this,
             sortFactor = this._sortFactor(),

--- a/views/admin_approvals.jade
+++ b/views/admin_approvals.jade
@@ -2,13 +2,33 @@ extends layout
 
 block bodyScripts
     script(type='text/javascript').
+        var approvals;
+        function approveSubscription(action, item) {
+          $.ajax({
+            url: `/admin/approvals/${action}`,
+            type: "POST",
+            dataType: "json",
+            data: {
+              id: item.id,
+              app: item.application.id,
+              api: item.api.id
+            }
+          }).done(function () {
+              $('#approvalsGrid').jsGrid("deleteItem", item);
+              approvals = approvals.filter(function(approval){ return approval.id != item.id; });
+          }).fail(function () {
+            alert(`Failed to ${action} subscription`);
+          }); 
+        }
+
         $(document).ready(function(){
+           approvals = !{approvals};     
            $('#approvalsGrid').jsGrid({
-             width: "100%", pageSize: 10, sorting: true, paging: true, filtering: true, autoload: true,
+             width: "100%", pageSize: 10, sorting: true, paging: true, filtering: true, autoload: true, confirmDeleting: false,
              controller: {
               loadData: function (filter) {
                   var d = $.Deferred();
-                  var data = !{approvals};
+                  var data = approvals;
                   if (isEmptyGridFilter(filter)) {
                     d.resolve(data);
                     return d.promise();
@@ -45,33 +65,26 @@ block bodyScripts
               { name: "plan.name", type: "text", title: "Plan" },
               { type: "actions",  type: "control", width: "100",
                       _createFilterSwitchButton: function() {
-                      return this._createOnOffSwitchButton("filtering", this.searchModeButtonClass, false);
-                    },
-                    itemTemplate: function(value,item) {
-                      var $form = $("<form>").attr("role", "form").attr("method","post")
-                                              .append("<input type='hidden' name='id' value='" + item.id + "'>")
-                                              .append("<input type='hidden' name='api' value='" + item.api.id + "'>")
-                                              .append("<input type='hidden' name='app' value='" + item.application.id + "'>");
-                      var $approveBtn = $("<button>").attr("type", "submit")
+                        return this._createOnOffSwitchButton("filtering", this.searchModeButtonClass, false);
+                      },
+                      itemTemplate: function(value,item) {
+                       var $approveBtn = $("<button>").attr("type", "submit")
                                                       .attr("class", "btn btn-sm btn-success")
                                                       .attr("style", "float: left; margin: 2px; width: 6em")
                                                       .text("Approve")
                                                       .on("click", function () {
-                                                        $form.attr("action", "/admin/approvals/approve");
-                                                        $form.submit();
+                                                       approveSubscription('approve', item);
                                                       });
-                      var $declineBtn = $("<button>").attr("type", "submit")
+                        var $declineBtn = $("<button>").attr("type", "submit")
                                                       .attr("class", "btn btn-sm btn-danger")
                                                       .attr("style", "float: left; margin: 2px; width: 6em")
                                                       .text("Decline")
                                                       .on("click", function () {
-                                                        $form.attr("action", "/admin/approvals/decline");
-                                                        $form.submit();
+                                                        approveSubscription('decline', item);
                                                       });
-                      return $("<td nowrap>").append($approveBtn)
+                       return $("<td nowrap>").append($approveBtn)
                                       .append("<span>&nbsp;</span>")
-                                      .append($declineBtn)
-                                      .append($form);
+                                      .append($declineBtn);
                     }
               }
             ]


### PR DESCRIPTION
Issue: Reset Search Filter after an action is taken  - Haufe-Lexware/wicked.haufe.io#203

Continuation of the previous PR closed due to a growing code base. And another implementation method was involved - https://github.com/apim-haufe-io/wicked.ui/pull/47